### PR TITLE
fix(version): Support three-part TrueNAS version strings

### DIFF
--- a/internal/api/version.go
+++ b/internal/api/version.go
@@ -26,11 +26,11 @@ type Version struct {
 	Raw    string
 }
 
-// versionRegex extracts version numbers from strings like "TrueNAS-SCALE-24.10.2.4"
-var versionRegex = regexp.MustCompile(`(\d+)\.(\d+)\.(\d+)\.(\d+)`)
+// versionRegex extracts version numbers from strings like "TrueNAS-SCALE-24.10.2.4" or "TrueNAS-25.10.1"
+var versionRegex = regexp.MustCompile(`(\d+)\.(\d+)\.(\d+)(?:\.(\d+))?`)
 
 // ParseVersion parses a TrueNAS version string.
-// Examples: "TrueNAS-SCALE-24.10.2.4", "TrueNAS-25.04.2.4"
+// Examples: "TrueNAS-SCALE-24.10.2.4", "TrueNAS-25.04.2.4", "TrueNAS-25.10.1"
 func ParseVersion(raw string) (Version, error) {
 	v := Version{Raw: raw}
 
@@ -63,9 +63,11 @@ func ParseVersion(raw string) (Version, error) {
 	if err != nil {
 		return v, fmt.Errorf("invalid patch version: %w", err)
 	}
-	v.Build, err = strconv.Atoi(match[4])
-	if err != nil {
-		return v, fmt.Errorf("invalid build version: %w", err)
+	if match[4] != "" {
+		v.Build, err = strconv.Atoi(match[4])
+		if err != nil {
+			return v, fmt.Errorf("invalid build version: %w", err)
+		}
 	}
 
 	return v, nil

--- a/internal/api/version_test.go
+++ b/internal/api/version_test.go
@@ -60,6 +60,18 @@ func TestParseVersion(t *testing.T) {
 			},
 		},
 		{
+			name: "TrueNAS 25.10 three-part version",
+			raw:  "TrueNAS-25.10.1",
+			want: Version{
+				Major:  25,
+				Minor:  10,
+				Patch:  1,
+				Build:  0,
+				Flavor: FlavorUnknown,
+				Raw:    "TrueNAS-25.10.1",
+			},
+		},
+		{
 			name:    "invalid version string",
 			raw:     "not-a-version",
 			wantErr: true,


### PR DESCRIPTION
Fixes #2.

TrueNAS 25.10+ uses three-part versions like `TrueNAS-25.10.1` instead of four-part `TrueNAS-SCALE-24.10.2.4`. This makes the build segment optional in the regex and defaults it to 0 when absent.

Two files changed, test included.