### PR TITLE
feat(ssh): Add SSH agent auth and configurable sudo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,3 +38,5 @@ require (
 	google.golang.org/grpc v1.75.1 // indirect
 	google.golang.org/protobuf v1.36.9 // indirect
 )
+
+replace github.com/deevus/truenas-go => /home/f33rx/src/f33rx/truenas-go

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,6 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deevus/truenas-go v0.5.0 h1:lsJC0I1tQ+zlBnnKSvJPupAVUk9rsf+95anl7P++IEI=
-github.com/deevus/truenas-go v0.5.0/go.mod h1:a5MwZEqT4NE8jwSA9BHONOAO8yH4kCaS5a+d4ad6sLA=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -34,6 +34,9 @@ type SSHBlockModel struct {
 	Port               types.Int64  `tfsdk:"port"`
 	User               types.String `tfsdk:"user"`
 	PrivateKey         types.String `tfsdk:"private_key"`
+	UseAgent           types.Bool   `tfsdk:"use_agent"`
+	AgentSocket        types.String `tfsdk:"agent_socket"`
+	UseSudo            types.Bool   `tfsdk:"use_sudo"`
 	HostKeyFingerprint types.String `tfsdk:"host_key_fingerprint"`
 	MaxSessions        types.Int64  `tfsdk:"max_sessions"`
 }
@@ -103,9 +106,21 @@ func (p *TrueNASProvider) Schema(ctx context.Context, req provider.SchemaRequest
 						Optional:    true,
 					},
 					"private_key": schema.StringAttribute{
-						Description: "SSH private key content.",
-						Required:    true,
+						Description: "SSH private key content. Required unless use_agent is true.",
+						Optional:    true,
 						Sensitive:   true,
+					},
+					"use_agent": schema.BoolAttribute{
+						Description: "Use SSH agent (SSH_AUTH_SOCK) for authentication instead of private_key.",
+						Optional:    true,
+					},
+					"agent_socket": schema.StringAttribute{
+						Description: "Path to SSH agent socket. Defaults to SSH_AUTH_SOCK environment variable.",
+						Optional:    true,
+					},
+					"use_sudo": schema.BoolAttribute{
+						Description: "Prefix commands with sudo. Defaults to true. Set to false when the SSH user can run midclt directly.",
+						Optional:    true,
 					},
 					"host_key_fingerprint": schema.StringAttribute{
 						Description: "SHA256 fingerprint of the TrueNAS server's SSH host key. " +
@@ -156,6 +171,34 @@ func (p *TrueNASProvider) Schema(ctx context.Context, req provider.SchemaRequest
 			},
 		},
 	}
+}
+
+func buildSSHConfig(host string, ssh *SSHBlockModel) *client.SSHConfig {
+	cfg := &client.SSHConfig{
+		Host:               host,
+		HostKeyFingerprint: ssh.HostKeyFingerprint.ValueString(),
+	}
+	if !ssh.UseAgent.IsNull() && ssh.UseAgent.ValueBool() {
+		cfg.UseAgent = true
+		if !ssh.AgentSocket.IsNull() {
+			cfg.AgentSocket = ssh.AgentSocket.ValueString()
+		}
+	} else {
+		cfg.PrivateKey = ssh.PrivateKey.ValueString()
+	}
+	if !ssh.Port.IsNull() {
+		cfg.Port = int(ssh.Port.ValueInt64())
+	}
+	if !ssh.User.IsNull() {
+		cfg.User = ssh.User.ValueString()
+	}
+	if !ssh.MaxSessions.IsNull() {
+		cfg.MaxSessions = int(ssh.MaxSessions.ValueInt64())
+	}
+	if !ssh.UseSudo.IsNull() && !ssh.UseSudo.ValueBool() {
+		cfg.NoSudo = true
+	}
+	return cfg
 }
 
 func (p *TrueNASProvider) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {
@@ -212,20 +255,7 @@ func (p *TrueNASProvider) Configure(ctx context.Context, req provider.ConfigureR
 		}
 
 		// Create SSH client for fallback
-		sshConfig := &client.SSHConfig{
-			Host:               config.Host.ValueString(),
-			PrivateKey:         config.SSH.PrivateKey.ValueString(),
-			HostKeyFingerprint: config.SSH.HostKeyFingerprint.ValueString(),
-		}
-		if !config.SSH.Port.IsNull() {
-			sshConfig.Port = int(config.SSH.Port.ValueInt64())
-		}
-		if !config.SSH.User.IsNull() {
-			sshConfig.User = config.SSH.User.ValueString()
-		}
-		if !config.SSH.MaxSessions.IsNull() {
-			sshConfig.MaxSessions = int(config.SSH.MaxSessions.ValueInt64())
-		}
+		sshConfig := buildSSHConfig(config.Host.ValueString(), config.SSH)
 
 		sshClient, err := factory.NewSSHClient(sshConfig)
 		if err != nil {
@@ -309,22 +339,7 @@ func (p *TrueNASProvider) Configure(ctx context.Context, req provider.ConfigureR
 		}
 
 		// Build SSH config with values from provider configuration
-		sshConfig := &client.SSHConfig{
-			Host:               config.Host.ValueString(),
-			PrivateKey:         config.SSH.PrivateKey.ValueString(),
-			HostKeyFingerprint: config.SSH.HostKeyFingerprint.ValueString(),
-		}
-
-		// Set optional values if provided
-		if !config.SSH.Port.IsNull() {
-			sshConfig.Port = int(config.SSH.Port.ValueInt64())
-		}
-		if !config.SSH.User.IsNull() {
-			sshConfig.User = config.SSH.User.ValueString()
-		}
-		if !config.SSH.MaxSessions.IsNull() {
-			sshConfig.MaxSessions = int(config.SSH.MaxSessions.ValueInt64())
-		}
+		sshConfig := buildSSHConfig(config.Host.ValueString(), config.SSH)
 
 		// Create SSH client (validates config and applies defaults)
 		sshClient, err := factory.NewSSHClient(sshConfig)


### PR DESCRIPTION
Adds three new options to the SSH provider block:

- **use_agent** / **agent_socket**: Authenticate via SSH agent instead of embedding a private key. Falls back to `SSH_AUTH_SOCK` if no socket is specified.
- **use_sudo**: Defaults to `true`. Set to `false` when the SSH user can run `midclt` directly (e.g. a TrueNAS admin account).

`private_key` becomes optional (still required when `use_agent` is false). The two are mutually exclusive.

Also refactors the duplicated SSH config construction into a shared `buildSSHConfig()` helper.

Tests included for all validation paths.