### PR TITLE
feat(app): Add catalog app support to truenas_app

### DIFF
--- a/internal/client/midclt.go
+++ b/internal/client/midclt.go
@@ -48,11 +48,14 @@ func BuildCommand(method string, params any) string {
 }
 
 // AppCreateParams represents parameters for app.create.
-// Simplified for custom Docker Compose apps only.
 type AppCreateParams struct {
-	AppName                   string `json:"app_name"`
-	CustomApp                 bool   `json:"custom_app"`
-	CustomComposeConfigString string `json:"custom_compose_config_string,omitempty"`
+	AppName                   string         `json:"app_name"`
+	CustomApp                 bool           `json:"custom_app"`
+	CustomComposeConfigString string         `json:"custom_compose_config_string,omitempty"`
+	CatalogApp                string         `json:"catalog_app,omitempty"`
+	Train                     string         `json:"train,omitempty"`
+	Version                   string         `json:"version,omitempty"`
+	Values                    map[string]any `json:"values,omitempty"`
 }
 
 // DatasetCreateParams represents parameters for pool.dataset.create.


### PR DESCRIPTION
Extends `truenas_app` to manage TrueNAS catalog apps (plex, tailscale, jellyfin, etc.) alongside existing custom Docker Compose apps.

**New attributes:**
- `catalog_app` — catalog name (e.g. `"plex"`)
- `train` — `"stable"` or `"community"`
- `version` — tracks installed version (computed after create)
- `values` — JSON-encoded config values passed to the app

`catalog_app` and `compose_config` are mutually exclusive. `values` is only valid with `catalog_app`.

**What changed:**
- `custom_app` is now computed (derived from whether `compose_config` is set)
- `AppCreateParams` extended with catalog fields
- Create/Read/Update/Import all handle both app types
- `ValidateConfig` enforces mutual exclusivity (skips when values are unknown at plan time)
- `queryApp` helper extracted to reduce duplication

Tests cover create, read, update, import, and validation for catalog apps.