### PR TITLE
fix(cloudsync_task): add support for fast_list option

### DIFF
--- a/docs/resources/cloudsync_task.md
+++ b/docs/resources/cloudsync_task.md
@@ -119,6 +119,7 @@ terraform import truenas_cloudsync_task.example 1
 - `enabled` (Boolean) Enable the task.
 - `encryption` (Block, Optional) Encryption settings for cloud storage. (see [below for nested schema](#nestedblock--encryption))
 - `exclude` (List of String) Patterns to exclude from sync.
+- `fast_list` (Boolean) Use fewer transactions in exchange for more memory. See rclone --fast-list.
 - `follow_symlinks` (Boolean) Follow symbolic links.
 - `gcs` (Block, Optional) Google Cloud Storage settings. (see [below for nested schema](#nestedblock--gcs))
 - `include` (List of String) Patterns to include in sync. Supports glob patterns like '/folder/**' or '*.jpg'.

--- a/internal/api/cloudsync.go
+++ b/internal/api/cloudsync.go
@@ -60,6 +60,18 @@ type CloudSyncTaskResponse struct {
 	Job                *JobStatus                 `json:"job,omitempty"`
 }
 
+// FastList returns the fast_list value from the task attributes.
+// Returns false if attributes is not an object or fast_list is not set.
+func (r *CloudSyncTaskResponse) FastList() bool {
+	var attrs struct {
+		FastList bool `json:"fast_list"`
+	}
+	if json.Unmarshal(r.Attributes, &attrs) != nil {
+		return false
+	}
+	return attrs.FastList
+}
+
 // BwLimit represents a bandwidth limit entry.
 type BwLimit struct {
 	Time      string `json:"time"`

--- a/internal/resources/cloudsync_task_test.go
+++ b/internal/resources/cloudsync_task_test.go
@@ -191,6 +191,7 @@ type cloudSyncTaskModelParams struct {
 	Include            []string
 	FollowSymlinks     bool
 	CreateEmptySrcDirs bool
+	FastList           bool
 	Enabled            bool
 	SyncOnChange       bool
 	Schedule           *scheduleBlockParams
@@ -280,6 +281,7 @@ func createCloudSyncTaskModelValue(p cloudSyncTaskModelParams) tftypes.Value {
 		"bwlimit":               tftypes.NewValue(tftypes.String, p.BWLimit),
 		"follow_symlinks":       tftypes.NewValue(tftypes.Bool, p.FollowSymlinks),
 		"create_empty_src_dirs": tftypes.NewValue(tftypes.Bool, p.CreateEmptySrcDirs),
+		"fast_list":             tftypes.NewValue(tftypes.Bool, p.FastList),
 		"enabled":               tftypes.NewValue(tftypes.Bool, p.Enabled),
 		"sync_on_change":        tftypes.NewValue(tftypes.Bool, p.SyncOnChange),
 	}
@@ -385,6 +387,7 @@ func createCloudSyncTaskModelValue(p cloudSyncTaskModelParams) tftypes.Value {
 			"include":               tftypes.List{ElementType: tftypes.String},
 			"follow_symlinks":       tftypes.Bool,
 			"create_empty_src_dirs": tftypes.Bool,
+			"fast_list":             tftypes.Bool,
 			"enabled":               tftypes.Bool,
 			"sync_on_change":        tftypes.Bool,
 			"schedule":              scheduleType,


### PR DESCRIPTION
The Cloud Sync Task resource previously did not provide the means to set the `Use --fast-list` option. This PR adds that.

Disclaimer: I did use claude code to help me generate this code. Feel free to dismiss this PR if that does not align with the project goals. I saw a CLAUDE.md file in the repo root so I assumed it would be fine.

I have tested this in my homelab with this code: https://github.com/mirceanton/truenas-apps/tree/feat!/terraform/terraform/truenas