### PR TITLE
feat: expand app resource to full TrueNAS API support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,54 @@
+NAME=terraform-provider-truenas
+VERSION ?= dev
+PROVIDER_HOSTNAME ?= registry.terraform.io
+PROVIDER_NAMESPACE ?= deevus
+PROVIDER_TYPE ?= truenas
+PROVIDER_SOURCE ?= $(PROVIDER_NAMESPACE)/$(PROVIDER_TYPE)
+PROVIDER_ADDRESS ?= $(PROVIDER_HOSTNAME)/$(PROVIDER_SOURCE)
+GOOS ?= $(shell go env GOOS)
+GOARCH ?= $(shell go env GOARCH)
+PLUGIN_DIR=$(HOME)/.terraform.d/plugins/$(PROVIDER_HOSTNAME)/$(PROVIDER_NAMESPACE)/$(PROVIDER_TYPE)/$(VERSION)/$(GOOS)_$(GOARCH)
+
+default: build
+
+.PHONY: build
+build:
+	go build -o $(NAME) .
+
+.PHONY: install
+install: build
+	mkdir -p $(PLUGIN_DIR)
+	cp $(NAME) $(PLUGIN_DIR)/
+
+.PHONY: test
+test:
+	go test ./...
+
+.PHONY: test-unit
+test-unit:
+	go test ./...
+
+.PHONY: fmt
+fmt:
+	gofmt -w .
+	go mod tidy
+
+.PHONY: docs
+docs:
+	go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs
+
+.PHONY: clean
+clean:
+	rm -f $(NAME)
+
+.PHONY: help
+help:
+	@echo "Available targets:"
+	@echo "  build      - Build the provider binary in the repo root"
+	@echo "  install    - Build and install the provider under ~/.terraform.d/plugins"
+	@echo "  test       - Run all Go tests"
+	@echo "  test-unit  - Run all Go tests"
+	@echo "  fmt        - Format code and tidy modules"
+	@echo "  docs       - Regenerate provider docs"
+	@echo "  clean      - Remove the built provider binary"
+	@echo "  help       - Show this help message"

--- a/README.md
+++ b/README.md
@@ -22,6 +22,29 @@ terraform {
 }
 ```
 
+## Build And Install
+
+```bash
+make build
+make install
+```
+
+`make build` writes the provider binary to the repo root as `terraform-provider-truenas`.
+
+`make install` copies it to:
+
+`~/.terraform.d/plugins/registry.terraform.io/deevus/truenas/${VERSION}/${GOOS}_${GOARCH}/`
+
+## Terraform CLI Config
+
+For local provider development, copy [example.tfrc](example.tfrc) to `~/.terraformrc`.
+
+The included example already points at:
+
+`/Users/aurimas/Code/GitHub/yavasura/terraform-provider-truenas`
+
+With that `dev_overrides` entry in place, any Terraform project that requests `deevus/truenas` will use the binary built in this repo root after you run `make build`.
+
 ## Usage
 
 ```hcl

--- a/docs/resources/app.md
+++ b/docs/resources/app.md
@@ -2,12 +2,12 @@
 page_title: "truenas_app Resource - terraform-provider-truenas"
 subcategory: ""
 description: |-
-  Manages a TrueNAS application (custom Docker Compose app or catalog app).
+  Manages a TrueNAS application using the TrueNAS app.create/app.update API.
 ---
 
 # truenas_app (Resource)
 
-Manages a TrueNAS application (custom Docker Compose app or catalog app).
+Manages a TrueNAS application using the TrueNAS app.create/app.update API.
 
 ## Example Usage
 
@@ -19,7 +19,7 @@ resource "truenas_app" "nginx" {
   name       = "nginx"
   custom_app = true
 
-  compose_config = <<-EOT
+  custom_compose_config_string = <<-EOT
     services:
       nginx:
         image: nginx:latest
@@ -58,7 +58,7 @@ resource "truenas_app" "example" {
   name       = "my-app"
   custom_app = true
 
-  compose_config = <<-EOF
+  custom_compose_config_string = <<-EOF
     services:
       web:
         image: nginx:latest
@@ -75,6 +75,26 @@ resource "truenas_app" "example" {
 
 > **Note:** Adding or removing `restart_triggers` does not trigger a restart. Only changes to existing trigger values cause the app to restart.
 
+### Catalog App
+
+```terraform
+resource "truenas_app" "plex" {
+  name        = "plex"
+  custom_app  = false
+  catalog_app = "plex"
+  train       = "stable"
+  version     = "latest"
+
+  values = {
+    resources = {
+      limits = {
+        cpu = 2
+      }
+    }
+  }
+}
+```
+
 ## Import
 
 Apps can be imported using the app name:
@@ -88,17 +108,36 @@ terraform import truenas_app.example my-app
 
 ### Required
 
-- `custom_app` (Boolean) Whether this is a custom Docker Compose application.
-- `name` (String) Application name.
+- `custom_app` (Boolean) Whether this is a custom Docker Compose application (`true`) or a catalog application (`false`).
+- `name` (String) Application name. Maps to the API's `app_name` field.
 
 ### Optional
 
-- `compose_config` (String) Docker Compose YAML configuration string (required for custom apps).
+- `catalog_app` (String) Catalog application name. Required when `custom_app` is false.
+- `compose_config` (String, Deprecated) Deprecated alias for `custom_compose_config_string`.
+- `custom_compose_config` (Dynamic) Structured Docker Compose configuration object for custom applications.
+- `custom_compose_config_string` (String) Docker Compose YAML configuration string for custom applications.
 - `desired_state` (String) Desired application state: 'running' or 'stopped' (case-insensitive). Defaults to 'RUNNING'.
+- `train` (String) Catalog train to install from. Defaults to `stable`.
+- `values` (Dynamic) Application values object passed to the API.
+- `version` (String) Desired catalog version selector for create/replace operations. Defaults to `latest`.
 - `restart_triggers` (Map of String) Map of values that, when changed, trigger an app restart. Use this to restart the app when dependent resources change, e.g., `restart_triggers = { config_checksum = truenas_file.config.checksum }`.
 - `state_timeout` (Number) Timeout in seconds to wait for state transitions. Defaults to 120. Range: 30-600.
 
 ### Read-Only
 
+- `active_workloads` (Dynamic) Active workload details reported by the API.
+- `config` (Dynamic) Current application config returned by the API.
+- `human_version` (String) Human-readable installed version string.
 - `id` (String) Application identifier (the app name).
+- `image_updates_available` (Boolean) Whether newer container images are available.
+- `installed_version` (String) Installed application version reported by the API.
+- `latest_app_version` (String) Latest application version reported by the API, if any.
+- `latest_version` (String) Latest available version reported by the API, if any.
+- `metadata` (Dynamic) Application metadata reported by the API.
+- `migrated` (Boolean) Whether the app was migrated from Kubernetes.
+- `notes` (String) Application notes reported by the API.
+- `portals` (Dynamic) Application portals reported by the API.
 - `state` (String) Application state (RUNNING, STOPPED, etc.).
+- `upgrade_available` (Boolean) Whether an upgrade is available for the application.
+- `version_details` (Dynamic) Detailed version information reported by the API.

--- a/example.tfrc
+++ b/example.tfrc
@@ -1,0 +1,7 @@
+provider_installation {
+  dev_overrides {
+    "deevus/truenas" = "/Users/aurimas/Code/GitHub/yavasura/terraform-provider-truenas"
+  }
+
+  direct {}
+}

--- a/examples/resources/app/main.tf
+++ b/examples/resources/app/main.tf
@@ -3,7 +3,7 @@ resource "truenas_app" "nginx" {
   name       = "nginx"
   custom_app = true
 
-  compose_config = <<-EOT
+  custom_compose_config_string = <<-EOT
     services:
       nginx:
         image: nginx:latest

--- a/internal/resources/app.go
+++ b/internal/resources/app.go
@@ -3,15 +3,16 @@ package resources
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"time"
 
-	truenas "github.com/deevus/truenas-go"
 	customtypes "github.com/deevus/terraform-provider-truenas/internal/types"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -23,6 +24,9 @@ import (
 var _ resource.Resource = &AppResource{}
 var _ resource.ResourceWithConfigure = &AppResource{}
 var _ resource.ResourceWithImportState = &AppResource{}
+var _ resource.ResourceWithValidateConfig = &AppResource{}
+
+var appNameRegexp = regexp.MustCompile(`^[a-z]([-a-z0-9]*[a-z0-9])?$`)
 
 // AppResource defines the resource implementation.
 type AppResource struct {
@@ -30,16 +34,34 @@ type AppResource struct {
 }
 
 // AppResourceModel describes the resource data model.
-// Simplified for custom Docker Compose apps only.
 type AppResourceModel struct {
-	ID              types.String                            `tfsdk:"id"`
-	Name            types.String                            `tfsdk:"name"`
-	CustomApp       types.Bool                              `tfsdk:"custom_app"`
-	ComposeConfig   customtypes.YAMLStringValue             `tfsdk:"compose_config"`
-	DesiredState    customtypes.CaseInsensitiveStringValue  `tfsdk:"desired_state"`
-	StateTimeout    types.Int64                             `tfsdk:"state_timeout"`
-	State           types.String                            `tfsdk:"state"`
-	RestartTriggers types.Map                               `tfsdk:"restart_triggers"`
+	ID                        types.String                           `tfsdk:"id"`
+	Name                      types.String                           `tfsdk:"name"`
+	CustomApp                 types.Bool                             `tfsdk:"custom_app"`
+	CatalogApp                types.String                           `tfsdk:"catalog_app"`
+	Train                     types.String                           `tfsdk:"train"`
+	Version                   types.String                           `tfsdk:"version"`
+	Values                    types.Dynamic                          `tfsdk:"values"`
+	CustomComposeConfig       types.Dynamic                          `tfsdk:"custom_compose_config"`
+	CustomComposeConfigString customtypes.YAMLStringValue            `tfsdk:"custom_compose_config_string"`
+	ComposeConfig             customtypes.YAMLStringValue            `tfsdk:"compose_config"`
+	DesiredState              customtypes.CaseInsensitiveStringValue `tfsdk:"desired_state"`
+	StateTimeout              types.Int64                            `tfsdk:"state_timeout"`
+	State                     types.String                           `tfsdk:"state"`
+	UpgradeAvailable          types.Bool                             `tfsdk:"upgrade_available"`
+	LatestVersion             types.String                           `tfsdk:"latest_version"`
+	LatestAppVersion          types.String                           `tfsdk:"latest_app_version"`
+	ImageUpdatesAvailable     types.Bool                             `tfsdk:"image_updates_available"`
+	Migrated                  types.Bool                             `tfsdk:"migrated"`
+	HumanVersion              types.String                           `tfsdk:"human_version"`
+	InstalledVersion          types.String                           `tfsdk:"installed_version"`
+	Metadata                  types.Dynamic                          `tfsdk:"metadata"`
+	ActiveWorkloads           types.Dynamic                          `tfsdk:"active_workloads"`
+	Notes                     types.String                           `tfsdk:"notes"`
+	Portals                   types.Dynamic                          `tfsdk:"portals"`
+	VersionDetails            types.Dynamic                          `tfsdk:"version_details"`
+	Config                    types.Dynamic                          `tfsdk:"config"`
+	RestartTriggers           types.Map                              `tfsdk:"restart_triggers"`
 }
 
 // NewAppResource creates a new AppResource.
@@ -53,7 +75,7 @@ func (r *AppResource) Metadata(ctx context.Context, req resource.MetadataRequest
 
 func (r *AppResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description: "Manages a TrueNAS application (custom Docker Compose app or catalog app).",
+		Description: "Manages a TrueNAS application using the TrueNAS app.create/app.update API.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description: "Application identifier (the app name).",
@@ -63,20 +85,64 @@ func (r *AppResource) Schema(ctx context.Context, req resource.SchemaRequest, re
 				},
 			},
 			"name": schema.StringAttribute{
-				Description: "Application name.",
+				Description: "Application name. Maps to the API's `app_name` field.",
 				Required:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
+				Validators: []validator.String{
+					stringvalidator.LengthBetween(1, 40),
+					stringvalidator.RegexMatches(appNameRegexp, "must match ^[a-z]([-a-z0-9]*[a-z0-9])?$"),
+				},
 			},
 			"custom_app": schema.BoolAttribute{
-				Description: "Whether this is a custom Docker Compose application.",
+				Description: "Whether this is a custom Docker Compose application (`true`) or a catalog application (`false`).",
 				Required:    true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.RequiresReplace(),
+				},
 			},
-			"compose_config": schema.StringAttribute{
-				Description: "Docker Compose YAML configuration string (required for custom apps).",
+			"catalog_app": schema.StringAttribute{
+				Description: "Catalog application name. Required when `custom_app` is false.",
+				Optional:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"train": schema.StringAttribute{
+				Description: "Catalog train to install from. Defaults to `stable`.",
+				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"version": schema.StringAttribute{
+				Description: "Desired catalog version selector for create/replace operations. Defaults to `latest`.",
+				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"values": schema.DynamicAttribute{
+				Description: "Application values object passed to the API.",
+				Optional:    true,
+			},
+			"custom_compose_config": schema.DynamicAttribute{
+				Description: "Structured Docker Compose configuration object for custom applications.",
+				Optional:    true,
+			},
+			"custom_compose_config_string": schema.StringAttribute{
+				Description: "Docker Compose YAML configuration string for custom applications.",
 				Optional:    true,
 				CustomType:  customtypes.YAMLStringType{},
+			},
+			"compose_config": schema.StringAttribute{
+				Description:        "Deprecated alias for `custom_compose_config_string`.",
+				Optional:           true,
+				CustomType:         customtypes.YAMLStringType{},
+				DeprecationMessage: "Use custom_compose_config_string instead. This alias will be removed in a future major release.",
 			},
 			"desired_state": schema.StringAttribute{
 				Description: "Desired application state: 'running' or 'stopped' (case-insensitive). Defaults to 'RUNNING'.",
@@ -106,6 +172,58 @@ func (r *AppResource) Schema(ctx context.Context, req resource.SchemaRequest, re
 					computedStatePlanModifier(),
 				},
 			},
+			"upgrade_available": schema.BoolAttribute{
+				Description: "Whether an upgrade is available for the application.",
+				Computed:    true,
+			},
+			"latest_version": schema.StringAttribute{
+				Description: "Latest available version reported by the API, if any.",
+				Computed:    true,
+			},
+			"latest_app_version": schema.StringAttribute{
+				Description: "Latest application version reported by the API, if any.",
+				Computed:    true,
+			},
+			"image_updates_available": schema.BoolAttribute{
+				Description: "Whether newer container images are available.",
+				Computed:    true,
+			},
+			"migrated": schema.BoolAttribute{
+				Description: "Whether the app was migrated from Kubernetes.",
+				Computed:    true,
+			},
+			"human_version": schema.StringAttribute{
+				Description: "Human-readable installed version string.",
+				Computed:    true,
+			},
+			"installed_version": schema.StringAttribute{
+				Description: "Installed application version reported by the API.",
+				Computed:    true,
+			},
+			"metadata": schema.DynamicAttribute{
+				Description: "Application metadata reported by the API.",
+				Computed:    true,
+			},
+			"active_workloads": schema.DynamicAttribute{
+				Description: "Active workload details reported by the API.",
+				Computed:    true,
+			},
+			"notes": schema.StringAttribute{
+				Description: "Application notes reported by the API.",
+				Computed:    true,
+			},
+			"portals": schema.DynamicAttribute{
+				Description: "Application portals reported by the API.",
+				Computed:    true,
+			},
+			"version_details": schema.DynamicAttribute{
+				Description: "Detailed version information reported by the API.",
+				Computed:    true,
+			},
+			"config": schema.DynamicAttribute{
+				Description: "Current application config returned by the API.",
+				Computed:    true,
+			},
 			"restart_triggers": schema.MapAttribute{
 				Description: "Map of values that, when changed, trigger an app restart. " +
 					"Use this to restart the app when dependent resources change, e.g., " +
@@ -117,6 +235,61 @@ func (r *AppResource) Schema(ctx context.Context, req resource.SchemaRequest, re
 	}
 }
 
+func (r *AppResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var data AppResourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if data.CustomApp.IsNull() || data.CustomApp.IsUnknown() {
+		return
+	}
+
+	hasComposeObject := !data.CustomComposeConfig.IsNull() && !data.CustomComposeConfig.IsUnknown()
+	hasComposeString := (!data.CustomComposeConfigString.IsNull() && !data.CustomComposeConfigString.IsUnknown() && data.CustomComposeConfigString.ValueString() != "") ||
+		(!data.ComposeConfig.IsNull() && !data.ComposeConfig.IsUnknown() && data.ComposeConfig.ValueString() != "")
+
+	if hasComposeObject && hasComposeString {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("custom_compose_config"),
+			"Conflicting Compose Configuration",
+			"Set only one of custom_compose_config, custom_compose_config_string, or compose_config.",
+		)
+	}
+
+	if data.CustomApp.ValueBool() {
+		if !data.CatalogApp.IsNull() && !data.CatalogApp.IsUnknown() && data.CatalogApp.ValueString() != "" {
+			resp.Diagnostics.AddAttributeError(
+				path.Root("catalog_app"),
+				"Unsupported Catalog Field For Custom App",
+				"catalog_app must not be set when custom_app is true.",
+			)
+		}
+		if !hasComposeObject && !hasComposeString {
+			resp.Diagnostics.AddError(
+				"Missing Custom App Configuration",
+				"Custom apps require one of custom_compose_config, custom_compose_config_string, or compose_config.",
+			)
+		}
+		return
+	}
+
+	if data.CatalogApp.IsNull() || data.CatalogApp.IsUnknown() || data.CatalogApp.ValueString() == "" {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("catalog_app"),
+			"Missing Catalog App",
+			"catalog_app is required when custom_app is false.",
+		)
+	}
+
+	if hasComposeObject || hasComposeString {
+		resp.Diagnostics.AddError(
+			"Unsupported Compose Configuration For Catalog App",
+			"Catalog apps do not support custom_compose_config, custom_compose_config_string, or compose_config.",
+		)
+	}
+}
 
 func (r *AppResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var data AppResourceModel
@@ -127,12 +300,17 @@ func (r *AppResource) Create(ctx context.Context, req resource.CreateRequest, re
 		return
 	}
 
-	// Build create opts
-	opts := r.buildCreateOpts(ctx, &data)
 	appName := data.Name.ValueString()
+	plannedValues := data.Values
 
-	// Call the TrueNAS API (CreateApp handles CallAndWait + GetApp internally)
-	app, err := r.services.App.CreateApp(ctx, opts)
+	if data.Train.IsNull() || data.Train.IsUnknown() || data.Train.ValueString() == "" {
+		data.Train = types.StringValue("stable")
+	}
+	if data.Version.IsNull() || data.Version.IsUnknown() || data.Version.ValueString() == "" {
+		data.Version = types.StringValue("latest")
+	}
+
+	app, err := r.createAppEntry(ctx, &data)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Create App",
@@ -142,8 +320,8 @@ func (r *AppResource) Create(ctx context.Context, req resource.CreateRequest, re
 	}
 
 	// Map response to model
-	data.ID = types.StringValue(app.Name)
-	data.State = types.StringValue(app.State)
+	r.syncAppStateToModel(&data, app, true)
+	data.Values = plannedValues
 
 	// Handle desired_state - if user wants STOPPED but app started as RUNNING
 	desiredState := data.DesiredState.ValueString()
@@ -216,12 +394,15 @@ func (r *AppResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 	priorDesiredState := data.DesiredState
 	priorStateTimeout := data.StateTimeout
 	priorRestartTriggers := data.RestartTriggers
+	priorCatalogApp := data.CatalogApp
+	priorTrain := data.Train
+	priorVersion := data.Version
+	priorValues := data.Values
 
 	// Use the name to query the app
 	appName := data.Name.ValueString()
 
-	// Call the TrueNAS API with config retrieval
-	app, err := r.services.App.GetAppWithConfig(ctx, appName)
+	app, err := r.readAppEntry(ctx, appName)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Read App",
@@ -237,31 +418,18 @@ func (r *AppResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 		return
 	}
 
-	// Map response to model - sync all fields from API
-	data.ID = types.StringValue(app.Name)
-	data.State = types.StringValue(app.State)
-	data.CustomApp = types.BoolValue(app.CustomApp)
-
-	// Sync compose_config if present
-	// The API returns the parsed compose config as a map, convert back to YAML
-	if len(app.Config) > 0 {
-		yamlBytes, err := yaml.Marshal(app.Config)
-		if err != nil {
-			resp.Diagnostics.AddError(
-				"Unable to Marshal Config",
-				fmt.Sprintf("Unable to marshal app config to YAML: %s", err.Error()),
-			)
-			return
-		}
-		data.ComposeConfig = customtypes.NewYAMLStringValue(string(yamlBytes))
-	} else {
-		data.ComposeConfig = customtypes.NewYAMLStringNull()
-	}
+	r.syncAppStateToModel(&data, app, false)
 
 	// Restore user-specified values from prior state
 	data.DesiredState = priorDesiredState
 	data.StateTimeout = priorStateTimeout
 	data.RestartTriggers = priorRestartTriggers
+	data.CatalogApp = priorCatalogApp
+	data.Train = priorTrain
+	data.Version = priorVersion
+	if !priorValues.IsNull() && !priorValues.IsUnknown() {
+		data.Values = priorValues
+	}
 
 	// Default desired_state if null/unknown (e.g., after import)
 	if data.DesiredState.IsNull() || data.DesiredState.IsUnknown() {
@@ -296,13 +464,12 @@ func (r *AppResource) Update(ctx context.Context, req resource.UpdateRequest, re
 	appName := data.Name.ValueString()
 
 	// Handle compose_config changes first (if any)
-	// Check if compose_config changed by comparing old and new values
-	composeConfigChanged := !data.ComposeConfig.Equal(stateData.ComposeConfig)
+	composeConfigChanged := !data.Values.Equal(stateData.Values) ||
+		!data.CustomComposeConfig.Equal(stateData.CustomComposeConfig) ||
+		!data.CustomComposeConfigString.Equal(stateData.CustomComposeConfigString) ||
+		!data.ComposeConfig.Equal(stateData.ComposeConfig)
 	if composeConfigChanged {
-		updateOpts := r.buildUpdateOpts(ctx, &data)
-
-		// Call app.update and wait for completion
-		_, err := r.services.App.UpdateApp(ctx, appName, updateOpts)
+		_, err := r.updateAppEntry(ctx, &data)
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Unable to Update App",
@@ -449,33 +616,6 @@ func (r *AppResource) ImportState(ctx context.Context, req resource.ImportStateR
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("name"), req.ID)...)
 }
 
-// buildCreateOpts builds the CreateAppOpts from the model.
-func (r *AppResource) buildCreateOpts(_ context.Context, data *AppResourceModel) truenas.CreateAppOpts {
-	opts := truenas.CreateAppOpts{
-		Name:      data.Name.ValueString(),
-		CustomApp: data.CustomApp.ValueBool(),
-	}
-
-	// Add compose config if set
-	if !data.ComposeConfig.IsNull() && !data.ComposeConfig.IsUnknown() {
-		opts.CustomComposeConfig = data.ComposeConfig.ValueString()
-	}
-
-	return opts
-}
-
-// buildUpdateOpts builds the UpdateAppOpts from the model.
-func (r *AppResource) buildUpdateOpts(_ context.Context, data *AppResourceModel) truenas.UpdateAppOpts {
-	opts := truenas.UpdateAppOpts{}
-
-	// Add compose config if set
-	if !data.ComposeConfig.IsNull() && !data.ComposeConfig.IsUnknown() {
-		opts.CustomComposeConfig = data.ComposeConfig.ValueString()
-	}
-
-	return opts
-}
-
 // queryAppState queries the TrueNAS API for the current state of an app.
 func (r *AppResource) queryAppState(ctx context.Context, name string) (string, error) {
 	app, err := r.services.App.GetApp(ctx, name)
@@ -488,6 +628,74 @@ func (r *AppResource) queryAppState(ctx context.Context, name string) (string, e
 	}
 
 	return app.State, nil
+}
+
+func (r *AppResource) syncAppStateToModel(data *AppResourceModel, app *appEntryResponse, preserveVersionSelector bool) {
+	id := app.ID
+	if id == "" {
+		id = app.Name
+	}
+
+	data.ID = types.StringValue(id)
+	data.State = types.StringValue(app.State)
+	data.CustomApp = types.BoolValue(app.CustomApp)
+	data.UpgradeAvailable = types.BoolValue(app.UpgradeAvailable)
+	if app.LatestVersion != nil {
+		data.LatestVersion = types.StringValue(*app.LatestVersion)
+	} else {
+		data.LatestVersion = types.StringNull()
+	}
+	if app.LatestAppVersion != nil {
+		data.LatestAppVersion = types.StringValue(*app.LatestAppVersion)
+	} else {
+		data.LatestAppVersion = types.StringNull()
+	}
+	data.ImageUpdatesAvailable = types.BoolValue(app.ImageUpdatesAvailable)
+	data.Migrated = types.BoolValue(app.Migrated)
+	if app.HumanVersion != "" {
+		data.HumanVersion = types.StringValue(app.HumanVersion)
+	} else {
+		data.HumanVersion = types.StringNull()
+	}
+	if app.Version != "" {
+		data.InstalledVersion = types.StringValue(app.Version)
+	} else {
+		data.InstalledVersion = types.StringNull()
+	}
+	data.Metadata = anyToDynamicValue(app.Metadata)
+	data.ActiveWorkloads = anyToDynamicValue(app.ActiveWorkloads)
+	if app.Notes != nil {
+		data.Notes = types.StringValue(*app.Notes)
+	} else {
+		data.Notes = types.StringNull()
+	}
+	data.Portals = anyToDynamicValue(app.Portals)
+	data.VersionDetails = anyToDynamicValue(app.VersionDetails)
+	data.Config = anyToDynamicValue(app.Config)
+
+	if app.CustomApp {
+		data.Values = types.DynamicNull()
+		data.CustomComposeConfig = anyToDynamicValue(app.Config)
+		if app.Config != nil {
+			yamlBytes, err := yaml.Marshal(app.Config)
+			if err == nil {
+				data.CustomComposeConfigString = customtypes.NewYAMLStringValue(string(yamlBytes))
+				data.ComposeConfig = customtypes.NewYAMLStringValue(string(yamlBytes))
+			}
+		} else {
+			data.CustomComposeConfigString = customtypes.NewYAMLStringNull()
+			data.ComposeConfig = customtypes.NewYAMLStringNull()
+		}
+	} else {
+		data.Values = anyToDynamicValue(app.Config)
+		data.CustomComposeConfig = types.DynamicNull()
+		data.CustomComposeConfigString = customtypes.NewYAMLStringNull()
+		data.ComposeConfig = customtypes.NewYAMLStringNull()
+	}
+
+	if !preserveVersionSelector && (data.Version.IsNull() || data.Version.IsUnknown()) {
+		data.Version = types.StringValue("latest")
+	}
 }
 
 // reconcileDesiredState ensures the app is in the desired state.

--- a/internal/resources/app_api.go
+++ b/internal/resources/app_api.go
@@ -1,0 +1,392 @@
+package resources
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math/big"
+
+	truenas "github.com/deevus/truenas-go"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type appEntryResponse struct {
+	ID                    string  `json:"id"`
+	Name                  string  `json:"name"`
+	State                 string  `json:"state"`
+	UpgradeAvailable      bool    `json:"upgrade_available"`
+	LatestVersion         *string `json:"latest_version"`
+	LatestAppVersion      *string `json:"latest_app_version"`
+	ImageUpdatesAvailable bool    `json:"image_updates_available"`
+	CustomApp             bool    `json:"custom_app"`
+	Migrated              bool    `json:"migrated"`
+	HumanVersion          string  `json:"human_version"`
+	Version               string  `json:"version"`
+	Metadata              any     `json:"metadata"`
+	ActiveWorkloads       any     `json:"active_workloads"`
+	Notes                 *string `json:"notes"`
+	Portals               any     `json:"portals"`
+	VersionDetails        any     `json:"version_details"`
+	Config                any     `json:"config"`
+}
+
+func (r *AppResource) createAppEntry(ctx context.Context, data *AppResourceModel) (*appEntryResponse, error) {
+	if r.client == nil {
+		opts := r.buildCreateOpts(data)
+		app, err := r.services.App.CreateApp(ctx, opts)
+		if err != nil {
+			return nil, err
+		}
+		return &appEntryResponse{
+			ID:        app.Name,
+			Name:      app.Name,
+			State:     app.State,
+			CustomApp: app.CustomApp,
+			Version:   app.Version,
+		}, nil
+	}
+
+	_, err := r.client.CallAndWait(ctx, "app.create", r.buildCreateParams(ctx, data))
+	if err != nil {
+		return nil, err
+	}
+
+	return r.readAppEntry(ctx, data.Name.ValueString())
+}
+
+func (r *AppResource) updateAppEntry(ctx context.Context, data *AppResourceModel) (*appEntryResponse, error) {
+	if r.client == nil {
+		app, err := r.services.App.UpdateApp(ctx, data.Name.ValueString(), r.buildUpdateOpts(data))
+		if err != nil {
+			return nil, err
+		}
+		return &appEntryResponse{
+			ID:        app.Name,
+			Name:      app.Name,
+			State:     app.State,
+			CustomApp: app.CustomApp,
+			Version:   app.Version,
+		}, nil
+	}
+
+	params := []any{data.Name.ValueString(), r.buildUpdateParams(ctx, data)}
+	if _, err := r.client.CallAndWait(ctx, "app.update", params); err != nil {
+		return nil, err
+	}
+
+	return r.readAppEntry(ctx, data.Name.ValueString())
+}
+
+func (r *AppResource) readAppEntry(ctx context.Context, name string) (*appEntryResponse, error) {
+	if r.client == nil {
+		app, err := r.services.App.GetAppWithConfig(ctx, name)
+		if err != nil {
+			return nil, err
+		}
+		if app == nil {
+			return nil, nil
+		}
+		return &appEntryResponse{
+			ID:               app.Name,
+			Name:             app.Name,
+			State:            app.State,
+			CustomApp:        app.CustomApp,
+			Version:          app.Version,
+			HumanVersion:     app.HumanVersion,
+			UpgradeAvailable: app.UpgradeAvailable,
+			LatestVersion:    stringPtrOrNil(app.LatestVersion),
+			ActiveWorkloads:  appActiveWorkloadsToAny(app.ActiveWorkloads),
+			Config:           app.Config,
+		}, nil
+	}
+
+	params := []any{
+		[][]any{{"name", "=", name}},
+		map[string]any{"extra": map[string]any{"retrieve_config": true}},
+	}
+	result, err := r.client.Call(ctx, "app.query", params)
+	if err != nil {
+		return nil, err
+	}
+
+	var entries []appEntryResponse
+	if err := json.Unmarshal(result, &entries); err != nil {
+		return nil, fmt.Errorf("parse app.query response: %w", err)
+	}
+
+	if len(entries) == 0 {
+		return nil, nil
+	}
+
+	return &entries[0], nil
+}
+
+func (r *AppResource) buildCreateParams(ctx context.Context, data *AppResourceModel) map[string]any {
+	params := map[string]any{
+		"app_name":   data.Name.ValueString(),
+		"custom_app": data.CustomApp.ValueBool(),
+	}
+
+	if value := dynamicValueToAny(ctx, data.Values); value != nil {
+		params["values"] = value
+	}
+	if value := dynamicValueToAny(ctx, data.CustomComposeConfig); value != nil {
+		params["custom_compose_config"] = value
+	}
+	if compose := r.effectiveComposeConfigString(data); compose != "" {
+		params["custom_compose_config_string"] = compose
+	}
+	if !data.CatalogApp.IsNull() && !data.CatalogApp.IsUnknown() {
+		params["catalog_app"] = data.CatalogApp.ValueString()
+	}
+	if !data.Train.IsNull() && !data.Train.IsUnknown() {
+		params["train"] = data.Train.ValueString()
+	}
+	if !data.Version.IsNull() && !data.Version.IsUnknown() {
+		params["version"] = data.Version.ValueString()
+	}
+
+	return params
+}
+
+func (r *AppResource) buildUpdateParams(ctx context.Context, data *AppResourceModel) map[string]any {
+	params := map[string]any{}
+
+	if value := dynamicValueToAny(ctx, data.Values); value != nil {
+		params["values"] = value
+	}
+	if value := dynamicValueToAny(ctx, data.CustomComposeConfig); value != nil {
+		params["custom_compose_config"] = value
+	}
+	if compose := r.effectiveComposeConfigString(data); compose != "" {
+		params["custom_compose_config_string"] = compose
+	}
+
+	return params
+}
+
+func (r *AppResource) buildCreateOpts(data *AppResourceModel) truenas.CreateAppOpts {
+	opts := truenas.CreateAppOpts{
+		Name:      data.Name.ValueString(),
+		CustomApp: data.CustomApp.ValueBool(),
+	}
+
+	if compose := r.effectiveComposeConfigString(data); compose != "" {
+		opts.CustomComposeConfig = compose
+	}
+
+	return opts
+}
+
+func (r *AppResource) buildUpdateOpts(data *AppResourceModel) truenas.UpdateAppOpts {
+	opts := truenas.UpdateAppOpts{}
+
+	if compose := r.effectiveComposeConfigString(data); compose != "" {
+		opts.CustomComposeConfig = compose
+	}
+
+	return opts
+}
+
+func (r *AppResource) effectiveComposeConfigString(data *AppResourceModel) string {
+	if !data.CustomComposeConfigString.IsNull() && !data.CustomComposeConfigString.IsUnknown() {
+		return data.CustomComposeConfigString.ValueString()
+	}
+	if !data.ComposeConfig.IsNull() && !data.ComposeConfig.IsUnknown() {
+		return data.ComposeConfig.ValueString()
+	}
+	return ""
+}
+
+func dynamicValueToAny(ctx context.Context, value types.Dynamic) any {
+	if value.IsNull() || value.IsUnknown() {
+		return nil
+	}
+
+	return attrValueToAny(ctx, value.UnderlyingValue())
+}
+
+func attrValueToAny(ctx context.Context, value attr.Value) any {
+	if value == nil || value.IsNull() || value.IsUnknown() {
+		return nil
+	}
+
+	switch v := value.(type) {
+	case types.Dynamic:
+		return dynamicValueToAny(ctx, v)
+	case types.String:
+		return v.ValueString()
+	case types.Bool:
+		return v.ValueBool()
+	case types.Int64:
+		return v.ValueInt64()
+	case types.Number:
+		f := v.ValueBigFloat()
+		if i, acc := f.Int64(); acc == big.Exact {
+			return i
+		}
+		floatVal, _ := f.Float64()
+		return floatVal
+	case types.List:
+		values := make([]any, 0, len(v.Elements()))
+		for _, elem := range v.Elements() {
+			values = append(values, attrValueToAny(ctx, elem))
+		}
+		return values
+	case types.Set:
+		values := make([]any, 0, len(v.Elements()))
+		for _, elem := range v.Elements() {
+			values = append(values, attrValueToAny(ctx, elem))
+		}
+		return values
+	case types.Map:
+		values := make(map[string]any, len(v.Elements()))
+		for key, elem := range v.Elements() {
+			values[key] = attrValueToAny(ctx, elem)
+		}
+		return values
+	case types.Object:
+		values := make(map[string]any, len(v.Attributes()))
+		for key, elem := range v.Attributes() {
+			values[key] = attrValueToAny(ctx, elem)
+		}
+		return values
+	default:
+		return nil
+	}
+}
+
+func anyToDynamicValue(value any) types.Dynamic {
+	attrValue := anyToAttrValue(value)
+	if attrValue == nil {
+		return types.DynamicNull()
+	}
+	return types.DynamicValue(attrValue)
+}
+
+func anyToAttrValue(value any) attr.Value {
+	switch v := value.(type) {
+	case nil:
+		return nil
+	case string:
+		return types.StringValue(v)
+	case bool:
+		return types.BoolValue(v)
+	case int:
+		return types.Int64Value(int64(v))
+	case int8:
+		return types.Int64Value(int64(v))
+	case int16:
+		return types.Int64Value(int64(v))
+	case int32:
+		return types.Int64Value(int64(v))
+	case int64:
+		return types.Int64Value(v)
+	case float32:
+		return types.NumberValue(big.NewFloat(float64(v)))
+	case float64:
+		return types.NumberValue(big.NewFloat(v))
+	case []any:
+		elements := make([]attr.Value, 0, len(v))
+		var elementType attr.Type = types.StringType
+		if len(v) > 0 {
+			first := anyToAttrValue(v[0])
+			if first != nil {
+				elementType = first.Type(context.Background())
+			}
+		}
+		for _, item := range v {
+			attrValue := anyToAttrValue(item)
+			if attrValue == nil {
+				elements = append(elements, types.StringNull())
+				continue
+			}
+			elements = append(elements, attrValue)
+		}
+		listValue, diags := types.ListValue(elementType, elements)
+		if diags.HasError() {
+			return nil
+		}
+		return listValue
+	case []string:
+		elements := make([]attr.Value, 0, len(v))
+		for _, item := range v {
+			elements = append(elements, types.StringValue(item))
+		}
+		listValue, diags := types.ListValue(types.StringType, elements)
+		if diags.HasError() {
+			return nil
+		}
+		return listValue
+	case map[string]any:
+		attrTypes := make(map[string]attr.Type, len(v))
+		attrs := make(map[string]attr.Value, len(v))
+		for key, item := range v {
+			attrValue := anyToAttrValue(item)
+			if attrValue == nil {
+				attrValue = types.DynamicNull()
+			}
+			attrTypes[key] = attrValue.Type(context.Background())
+			attrs[key] = attrValue
+		}
+		objectValue, diags := types.ObjectValue(attrTypes, attrs)
+		if diags.HasError() {
+			return nil
+		}
+		return objectValue
+	default:
+		jsonBytes, err := json.Marshal(v)
+		if err != nil {
+			return nil
+		}
+
+		var generic any
+		if err := json.Unmarshal(jsonBytes, &generic); err != nil {
+			return nil
+		}
+
+		return anyToAttrValue(generic)
+	}
+}
+
+func stringPtrOrNil(value string) *string {
+	if value == "" {
+		return nil
+	}
+	return &value
+}
+
+func appActiveWorkloadsToAny(workloads truenas.AppActiveWorkloads) map[string]any {
+	usedPorts := make([]any, 0, len(workloads.UsedPorts))
+	for _, port := range workloads.UsedPorts {
+		hostPorts := []any{
+			map[string]any{
+				"host_port": port.HostPort,
+				"host_ip":   "",
+			},
+		}
+		usedPorts = append(usedPorts, map[string]any{
+			"container_port": port.ContainerPort,
+			"protocol":       port.Protocol,
+			"host_ports":     hostPorts,
+		})
+	}
+
+	containerDetails := make([]any, 0, len(workloads.ContainerDetails))
+	for _, container := range workloads.ContainerDetails {
+		containerDetails = append(containerDetails, map[string]any{
+			"id":           container.ID,
+			"service_name": container.ServiceName,
+			"image":        container.Image,
+			"state":        string(container.State),
+		})
+	}
+
+	return map[string]any{
+		"containers":        workloads.Containers,
+		"used_ports":        usedPorts,
+		"used_host_ips":     []any{},
+		"container_details": containerDetails,
+	}
+}

--- a/internal/resources/app_test.go
+++ b/internal/resources/app_test.go
@@ -2,17 +2,21 @@ package resources
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
 	"time"
 
-	truenas "github.com/deevus/truenas-go"
 	"github.com/deevus/terraform-provider-truenas/internal/services"
 	customtypes "github.com/deevus/terraform-provider-truenas/internal/types"
+	truenas "github.com/deevus/truenas-go"
+	"github.com/deevus/truenas-go/client"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
 
@@ -111,7 +115,6 @@ func TestAppResource_Schema(t *testing.T) {
 	}
 }
 
-
 // getAppResourceSchema returns the schema for the app resource
 func getAppResourceSchema(t *testing.T) resource.SchemaResponse {
 	t.Helper()
@@ -125,14 +128,33 @@ func getAppResourceSchema(t *testing.T) resource.SchemaResponse {
 // appModelParams contains parameters for creating test app resource model values.
 // All fields are optional - nil values result in null tftypes values.
 type appModelParams struct {
-	ID              interface{}            // Resource ID (usually same as Name)
-	Name            interface{}            // App name
-	CustomApp       interface{}            // Whether this is a custom app (usually true)
-	ComposeConfig   interface{}            // Docker Compose YAML config
-	DesiredState    interface{}            // Desired state: "RUNNING", "STOPPED", "running", "stopped"
-	StateTimeout    interface{}            // Timeout in seconds (as float64)
-	State           interface{}            // Actual state from API
-	RestartTriggers map[string]interface{} // Map of trigger keys to values
+	ID                        interface{}            // Resource ID (usually same as Name)
+	Name                      interface{}            // App name
+	CustomApp                 interface{}            // Whether this is a custom app (usually true)
+	CatalogApp                interface{}            // Catalog app name
+	Train                     interface{}            // Catalog train
+	Version                   interface{}            // Desired version selector
+	Values                    interface{}            // Values object
+	CustomComposeConfig       interface{}            // Structured compose config
+	CustomComposeConfigString interface{}            // Compose config string
+	ComposeConfig             interface{}            // Deprecated compose config alias
+	DesiredState              interface{}            // Desired state: "RUNNING", "STOPPED", "running", "stopped"
+	StateTimeout              interface{}            // Timeout in seconds (as float64)
+	State                     interface{}            // Actual state from API
+	UpgradeAvailable          interface{}            // Whether upgrade is available
+	LatestVersion             interface{}            // Latest version from API
+	LatestAppVersion          interface{}            // Latest app version from API
+	ImageUpdatesAvailable     interface{}            // Whether image updates are available
+	Migrated                  interface{}            // Whether app was migrated
+	HumanVersion              interface{}            // Human version string
+	InstalledVersion          interface{}            // Installed version from API
+	Metadata                  interface{}            // Metadata object
+	ActiveWorkloads           interface{}            // Active workloads object
+	Notes                     interface{}            // Notes string
+	Portals                   interface{}            // Portals object
+	VersionDetails            interface{}            // Version details object
+	Config                    interface{}            // Current API config object
+	RestartTriggers           map[string]interface{} // Map of trigger keys to values
 }
 
 // newAppModelValue creates a tftypes.Value from appModelParams.
@@ -149,27 +171,151 @@ func newAppModelValue(p appModelParams) tftypes.Value {
 		triggersValue = tftypes.NewValue(tftypes.Map{ElementType: tftypes.String}, triggerMap)
 	}
 
+	dynamicValue := func(v interface{}) tftypes.Value {
+		if v == nil {
+			return tftypes.NewValue(tftypes.DynamicPseudoType, nil)
+		}
+
+		switch val := v.(type) {
+		case map[string]interface{}:
+			return tftypes.NewValue(tftypes.DynamicPseudoType, toDynamicTFData(val))
+		case []interface{}:
+			return tftypes.NewValue(tftypes.DynamicPseudoType, toDynamicTFData(val))
+		default:
+			return tftypes.NewValue(tftypes.DynamicPseudoType, val)
+		}
+	}
+
 	return tftypes.NewValue(tftypes.Object{
 		AttributeTypes: map[string]tftypes.Type{
-			"id":               tftypes.String,
-			"name":             tftypes.String,
-			"custom_app":       tftypes.Bool,
-			"compose_config":   tftypes.String,
-			"desired_state":    tftypes.String,
-			"state_timeout":    tftypes.Number,
-			"state":            tftypes.String,
-			"restart_triggers": tftypes.Map{ElementType: tftypes.String},
+			"id":                           tftypes.String,
+			"name":                         tftypes.String,
+			"custom_app":                   tftypes.Bool,
+			"catalog_app":                  tftypes.String,
+			"train":                        tftypes.String,
+			"version":                      tftypes.String,
+			"values":                       tftypes.DynamicPseudoType,
+			"custom_compose_config":        tftypes.DynamicPseudoType,
+			"custom_compose_config_string": tftypes.String,
+			"compose_config":               tftypes.String,
+			"desired_state":                tftypes.String,
+			"state_timeout":                tftypes.Number,
+			"state":                        tftypes.String,
+			"upgrade_available":            tftypes.Bool,
+			"latest_version":               tftypes.String,
+			"latest_app_version":           tftypes.String,
+			"image_updates_available":      tftypes.Bool,
+			"migrated":                     tftypes.Bool,
+			"human_version":                tftypes.String,
+			"installed_version":            tftypes.String,
+			"metadata":                     tftypes.DynamicPseudoType,
+			"active_workloads":             tftypes.DynamicPseudoType,
+			"notes":                        tftypes.String,
+			"portals":                      tftypes.DynamicPseudoType,
+			"version_details":              tftypes.DynamicPseudoType,
+			"config":                       tftypes.DynamicPseudoType,
+			"restart_triggers":             tftypes.Map{ElementType: tftypes.String},
 		},
 	}, map[string]tftypes.Value{
-		"id":               tftypes.NewValue(tftypes.String, p.ID),
-		"name":             tftypes.NewValue(tftypes.String, p.Name),
-		"custom_app":       tftypes.NewValue(tftypes.Bool, p.CustomApp),
-		"compose_config":   tftypes.NewValue(tftypes.String, p.ComposeConfig),
-		"desired_state":    tftypes.NewValue(tftypes.String, p.DesiredState),
-		"state_timeout":    tftypes.NewValue(tftypes.Number, p.StateTimeout),
-		"state":            tftypes.NewValue(tftypes.String, p.State),
-		"restart_triggers": triggersValue,
+		"id":                           tftypes.NewValue(tftypes.String, p.ID),
+		"name":                         tftypes.NewValue(tftypes.String, p.Name),
+		"custom_app":                   tftypes.NewValue(tftypes.Bool, p.CustomApp),
+		"catalog_app":                  tftypes.NewValue(tftypes.String, p.CatalogApp),
+		"train":                        tftypes.NewValue(tftypes.String, p.Train),
+		"version":                      tftypes.NewValue(tftypes.String, p.Version),
+		"values":                       dynamicValue(p.Values),
+		"custom_compose_config":        dynamicValue(p.CustomComposeConfig),
+		"custom_compose_config_string": tftypes.NewValue(tftypes.String, p.CustomComposeConfigString),
+		"compose_config":               tftypes.NewValue(tftypes.String, p.ComposeConfig),
+		"desired_state":                tftypes.NewValue(tftypes.String, p.DesiredState),
+		"state_timeout":                tftypes.NewValue(tftypes.Number, p.StateTimeout),
+		"state":                        tftypes.NewValue(tftypes.String, p.State),
+		"upgrade_available":            tftypes.NewValue(tftypes.Bool, p.UpgradeAvailable),
+		"latest_version":               tftypes.NewValue(tftypes.String, p.LatestVersion),
+		"latest_app_version":           tftypes.NewValue(tftypes.String, p.LatestAppVersion),
+		"image_updates_available":      tftypes.NewValue(tftypes.Bool, p.ImageUpdatesAvailable),
+		"migrated":                     tftypes.NewValue(tftypes.Bool, p.Migrated),
+		"human_version":                tftypes.NewValue(tftypes.String, p.HumanVersion),
+		"installed_version":            tftypes.NewValue(tftypes.String, p.InstalledVersion),
+		"metadata":                     dynamicValue(p.Metadata),
+		"active_workloads":             dynamicValue(p.ActiveWorkloads),
+		"notes":                        tftypes.NewValue(tftypes.String, p.Notes),
+		"portals":                      dynamicValue(p.Portals),
+		"version_details":              dynamicValue(p.VersionDetails),
+		"config":                       dynamicValue(p.Config),
+		"restart_triggers":             triggersValue,
 	})
+}
+
+func toDynamicTFData(v interface{}) interface{} {
+	switch val := v.(type) {
+	case map[string]interface{}:
+		attrs := make(map[string]tftypes.Value, len(val))
+		for k, item := range val {
+			child := toDynamicTFTValue(item)
+			attrs[k] = child
+		}
+		return attrs
+	case []interface{}:
+		values := make([]tftypes.Value, 0, len(val))
+		for _, item := range val {
+			child := toDynamicTFTValue(item)
+			values = append(values, child)
+		}
+		return values
+	case string:
+		return val
+	case bool:
+		return val
+	case int:
+		return int64(val)
+	case int64:
+		return val
+	case float64:
+		return val
+	default:
+		return ""
+	}
+}
+
+func toDynamicTFTValue(v interface{}) tftypes.Value {
+	switch val := v.(type) {
+	case map[string]interface{}:
+		attrs := make(map[string]tftypes.Value, len(val))
+		attrTypes := make(map[string]tftypes.Type, len(val))
+		for k, item := range val {
+			child := toDynamicTFTValue(item)
+			attrs[k] = child
+			attrTypes[k] = child.Type()
+		}
+		return tftypes.NewValue(tftypes.Object{AttributeTypes: attrTypes}, attrs)
+	case []interface{}:
+		if len(val) == 0 {
+			return tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, []tftypes.Value{})
+		}
+		values := make([]tftypes.Value, 0, len(val))
+		var elementType tftypes.Type = tftypes.String
+		for i, item := range val {
+			child := toDynamicTFTValue(item)
+			values = append(values, child)
+			if i == 0 {
+				elementType = child.Type()
+			}
+		}
+		return tftypes.NewValue(tftypes.List{ElementType: elementType}, values)
+	case string:
+		return tftypes.NewValue(tftypes.String, val)
+	case bool:
+		return tftypes.NewValue(tftypes.Bool, val)
+	case int:
+		return tftypes.NewValue(tftypes.Number, int64(val))
+	case int64:
+		return tftypes.NewValue(tftypes.Number, val)
+	case float64:
+		return tftypes.NewValue(tftypes.Number, val)
+	default:
+		return tftypes.NewValue(tftypes.String, "")
+	}
 }
 
 // createAppResourceModelValue creates a tftypes.Value for the app resource model.
@@ -267,9 +413,9 @@ func TestAppResource_Create_Success(t *testing.T) {
 
 	// Verify state was set
 	var model AppResourceModel
-	diags := resp.State.Get(context.Background(), &model)
-	if diags.HasError() {
-		t.Fatalf("failed to get state: %v", diags)
+	stateDiags := resp.State.Get(context.Background(), &model)
+	if stateDiags.HasError() {
+		t.Fatalf("failed to get state: %v", stateDiags)
 	}
 
 	if model.ID.ValueString() != "myapp" {
@@ -797,9 +943,9 @@ func TestAppResource_Read_EmptyComposeConfigSetsNull(t *testing.T) {
 	}
 
 	var model AppResourceModel
-	diags := resp.State.Get(context.Background(), &model)
-	if diags.HasError() {
-		t.Fatalf("failed to get state: %v", diags)
+	stateDiags := resp.State.Get(context.Background(), &model)
+	if stateDiags.HasError() {
+		t.Fatalf("failed to get state: %v", stateDiags)
 	}
 
 	// compose_config should be null when API returns empty config
@@ -2323,5 +2469,248 @@ func TestAppResource_Update_DesiredStateCasePreservation(t *testing.T) {
 	// State should reflect the actual API state
 	if model.State.ValueString() != "STOPPED" {
 		t.Errorf("expected state 'STOPPED', got %q", model.State.ValueString())
+	}
+}
+
+func TestAppResource_buildCreateParams_CatalogApp(t *testing.T) {
+	values := types.ObjectValueMust(
+		map[string]attr.Type{"replicas": types.Int64Type},
+		map[string]attr.Value{"replicas": types.Int64Value(2)},
+	)
+
+	r := &AppResource{}
+	model := &AppResourceModel{
+		Name:       types.StringValue("plex"),
+		CustomApp:  types.BoolValue(false),
+		CatalogApp: types.StringValue("plex"),
+		Train:      types.StringValue("stable"),
+		Version:    types.StringValue("1.2.3"),
+		Values:     types.DynamicValue(values),
+	}
+
+	params := r.buildCreateParams(context.Background(), model)
+
+	if params["app_name"] != "plex" {
+		t.Fatalf("expected app_name plex, got %#v", params["app_name"])
+	}
+	if params["catalog_app"] != "plex" {
+		t.Fatalf("expected catalog_app plex, got %#v", params["catalog_app"])
+	}
+	if params["train"] != "stable" {
+		t.Fatalf("expected train stable, got %#v", params["train"])
+	}
+	if params["version"] != "1.2.3" {
+		t.Fatalf("expected version 1.2.3, got %#v", params["version"])
+	}
+
+	valuesMap, ok := params["values"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected values map, got %T", params["values"])
+	}
+	if valuesMap["replicas"] != int64(2) {
+		t.Fatalf("expected replicas 2, got %#v", valuesMap["replicas"])
+	}
+}
+
+func TestAppResource_Read_RawClientCatalogAppMapsValues(t *testing.T) {
+	r := &AppResource{
+		BaseResource: BaseResource{
+			client: &client.MockClient{
+				CallFunc: func(ctx context.Context, method string, params any) (json.RawMessage, error) {
+					if method != "app.query" {
+						t.Fatalf("unexpected method %q", method)
+					}
+
+					return json.RawMessage(`[
+						{
+							"id": "plex",
+							"name": "plex",
+							"state": "RUNNING",
+							"custom_app": false,
+							"version": "2.0.0",
+							"human_version": "2.0.0_1.0.0",
+							"upgrade_available": true,
+							"latest_version": "2.1.0",
+							"latest_app_version": "2.1.0",
+							"image_updates_available": false,
+							"migrated": false,
+							"metadata": {"icon": "plex.svg"},
+							"active_workloads": {"containers": 1},
+							"notes": "hello",
+							"portals": {"web": "http://plex.local"},
+							"version_details": {"healthy": true},
+							"config": {"resources": {"limits": {"cpu": 2}}}
+						}
+					]`), nil
+				},
+			},
+		},
+	}
+
+	schemaResp := getAppResourceSchema(t)
+	stateValue := newAppModelValue(appModelParams{
+		ID:         "plex",
+		Name:       "plex",
+		CustomApp:  false,
+		CatalogApp: "plex",
+		Train:      "stable",
+		Version:    "latest",
+		State:      "RUNNING",
+	})
+
+	req := resource.ReadRequest{
+		State: tfsdk.State{
+			Schema: schemaResp.Schema,
+			Raw:    stateValue,
+		},
+	}
+	resp := &resource.ReadResponse{
+		State: tfsdk.State{
+			Schema: schemaResp.Schema,
+		},
+	}
+
+	r.Read(context.Background(), req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected errors: %v", resp.Diagnostics)
+	}
+
+	var model AppResourceModel
+	diags := resp.State.Get(context.Background(), &model)
+	if diags.HasError() {
+		t.Fatalf("failed to get state: %v", diags)
+	}
+
+	if model.CustomApp.ValueBool() {
+		t.Fatal("expected catalog app")
+	}
+	if model.Values.IsNull() {
+		t.Fatal("expected values to be populated from API config")
+	}
+	if model.CustomComposeConfigString.IsNull() == false {
+		t.Fatal("expected custom compose config string to stay null for catalog app")
+	}
+	if model.InstalledVersion.ValueString() != "2.0.0" {
+		t.Fatalf("expected installed version 2.0.0, got %q", model.InstalledVersion.ValueString())
+	}
+	if !model.UpgradeAvailable.ValueBool() {
+		t.Fatal("expected upgrade_available to be true")
+	}
+}
+
+func TestAppResource_Read_RawClientCatalogAppPreservesPriorValues(t *testing.T) {
+	r := &AppResource{
+		BaseResource: BaseResource{
+			client: &client.MockClient{
+				CallFunc: func(ctx context.Context, method string, params any) (json.RawMessage, error) {
+					return json.RawMessage(`[
+						{
+							"id": "minio",
+							"name": "minio",
+							"state": "RUNNING",
+							"custom_app": false,
+							"config": {
+								"minio": {"existingSecret": "redacted"},
+								"network": {"api_port": {"port_number": 9000}}
+							}
+						}
+					]`), nil
+				},
+			},
+		},
+	}
+
+	schemaResp := getAppResourceSchema(t)
+	plannedValues, diags := types.ObjectValue(
+		map[string]attr.Type{
+			"minio": types.ObjectType{AttrTypes: map[string]attr.Type{
+				"rootUser": types.StringType,
+			}},
+			"network": types.ObjectType{AttrTypes: map[string]attr.Type{
+				"api_port": types.ObjectType{AttrTypes: map[string]attr.Type{
+					"port_number": types.Int64Type,
+				}},
+			}},
+		},
+		map[string]attr.Value{
+			"minio": types.ObjectValueMust(
+				map[string]attr.Type{"rootUser": types.StringType},
+				map[string]attr.Value{"rootUser": types.StringValue("admin")},
+			),
+			"network": types.ObjectValueMust(
+				map[string]attr.Type{
+					"api_port": types.ObjectType{AttrTypes: map[string]attr.Type{
+						"port_number": types.Int64Type,
+					}},
+				},
+				map[string]attr.Value{
+					"api_port": types.ObjectValueMust(
+						map[string]attr.Type{"port_number": types.Int64Type},
+						map[string]attr.Value{"port_number": types.Int64Value(9000)},
+					),
+				},
+			),
+		},
+	)
+	if diags.HasError() {
+		t.Fatalf("failed to build planned values: %v", diags)
+	}
+
+	priorState := tfsdk.State{Schema: schemaResp.Schema}
+	setDiags := priorState.Set(context.Background(), &AppResourceModel{
+		ID:              types.StringValue("minio"),
+		Name:            types.StringValue("minio"),
+		CustomApp:       types.BoolValue(false),
+		CatalogApp:      types.StringValue("minio"),
+		Train:           types.StringValue("stable"),
+		Version:         types.StringValue("latest"),
+		Values:          types.DynamicValue(plannedValues),
+		State:           types.StringValue("RUNNING"),
+		RestartTriggers: types.MapNull(types.StringType),
+	})
+	if setDiags.HasError() {
+		t.Fatalf("failed to build prior state: %v", setDiags)
+	}
+
+	req := resource.ReadRequest{
+		State: priorState,
+	}
+	resp := &resource.ReadResponse{
+		State: tfsdk.State{
+			Schema: schemaResp.Schema,
+		},
+	}
+
+	r.Read(context.Background(), req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected errors: %v", resp.Diagnostics)
+	}
+
+	var model AppResourceModel
+	diags = resp.State.Get(context.Background(), &model)
+	if diags.HasError() {
+		t.Fatalf("failed to get state: %v", diags)
+	}
+
+	valuesObj, ok := model.Values.UnderlyingValue().(types.Object)
+	if !ok {
+		t.Fatalf("expected object underlying value, got %T", model.Values.UnderlyingValue())
+	}
+	minioVal, ok := valuesObj.Attributes()["minio"].(types.Object)
+	if !ok {
+		t.Fatalf("expected minio object, got %T", valuesObj.Attributes()["minio"])
+	}
+	rootUser, ok := minioVal.Attributes()["rootUser"].(types.String)
+	if !ok {
+		t.Fatalf("expected rootUser string, got %T", minioVal.Attributes()["rootUser"])
+	}
+	if rootUser.ValueString() != "admin" {
+		t.Fatalf("expected preserved rootUser admin, got %q", rootUser.ValueString())
+	}
+
+	if model.Config.IsNull() {
+		t.Fatal("expected API config to still be populated in computed config field")
 	}
 }

--- a/templates/resources/app.md.tmpl
+++ b/templates/resources/app.md.tmpl
@@ -35,7 +35,7 @@ resource "truenas_app" "example" {
   name       = "my-app"
   custom_app = true
 
-  compose_config = <<-EOF
+  custom_compose_config_string = <<-EOF
     services:
       web:
         image: nginx:latest
@@ -51,6 +51,26 @@ resource "truenas_app" "example" {
 ```
 
 > **Note:** Adding or removing `restart_triggers` does not trigger a restart. Only changes to existing trigger values cause the app to restart.
+
+### Catalog App
+
+```terraform
+resource "truenas_app" "plex" {
+  name        = "plex"
+  custom_app  = false
+  catalog_app = "plex"
+  train       = "stable"
+  version     = "latest"
+
+  values = {
+    resources = {
+      limits = {
+        cpu = 2
+      }
+    }
+  }
+}
+```
 
 ## Import
 


### PR DESCRIPTION
## Summary

This PR expands the `truenas_app` resource to support the TrueNAS app API more completely, including catalog apps in addition to custom apps.

It also fixes provider state handling for sensitive catalog app values and adds a local development workflow for using the provider via Terraform `dev_overrides`.

## What Changed

- expand `truenas_app` schema to support catalog app fields:
  - `catalog_app`
  - `train`
  - `version`
  - `values`
  - `custom_compose_config`
  - `custom_compose_config_string`
- keep `compose_config` as a deprecated compatibility alias
- add config validation for custom vs catalog app payload rules
- add raw app API helpers for create, update, and query behavior
- expose additional computed API fields such as:
  - `config`
  - `installed_version`
  - `latest_version`
  - `latest_app_version`
  - `metadata`
  - `active_workloads`
  - `portals`
  - `version_details`
- preserve configured `values` in Terraform state instead of overwriting them with API-returned `config`
- add tests covering catalog app payload/state handling
- update docs and examples
- add local dev workflow files:
  - `Makefile`
  - `example.tfrc`
  - README setup instructions

## Why

Before this change, the resource behavior did not match the TrueNAS app API for catalog app installs.

This PR aligns the provider more closely with the real API surface and fixes a state consistency issue that showed up with sensitive catalog app values during apply.

## Verification

- `go test ./internal/resources -run TestApp`
- `go test ./...`
- validated by applying a MinIO catalog app through the local dev provider override

## Notes

- `compose_config` is retained for backward compatibility, but the newer fields better reflect the actual API
- local Terraform development can now use `dev_overrides` against this repo directly
