### PR TITLE
feat: add memory and cpu attributes to virt_instance resource

### DIFF
--- a/docs/resources/virt_instance.md
+++ b/docs/resources/virt_instance.md
@@ -22,6 +22,8 @@ resource "truenas_virt_instance" "example" {
   image_name    = "ubuntu"
   image_version = "24.04"
   storage_pool  = "tank"
+  memory        = 4294967296
+  cpu           = "2"
   autostart     = true
 }
 ```
@@ -129,8 +131,10 @@ terraform import truenas_virt_instance.example my-container
 ### Optional
 
 - `autostart` (Boolean) Whether to start the container automatically on boot. Defaults to false.
+- `cpu` (String) CPU allocation (e.g., '2' for 2 cores).
 - `desired_state` (String) Desired container state: 'RUNNING' or 'STOPPED'. Defaults to 'RUNNING'.
 - `disk` (Block List) Disk devices to attach to the container. (see [below for nested schema](#nestedblock--disk))
+- `memory` (Number) Memory allocation in bytes. Minimum 33554432 (32 MiB).
 - `nic` (Block List) Network interfaces to attach to the container. (see [below for nested schema](#nestedblock--nic))
 - `proxy` (Block List) Port proxies/forwards for the container. (see [below for nested schema](#nestedblock--proxy))
 - `shutdown_timeout` (Number) Timeout in seconds for graceful shutdown. Defaults to 30.

--- a/internal/resources/virt_instance.go
+++ b/internal/resources/virt_instance.go
@@ -43,6 +43,8 @@ type VirtInstanceResourceModel struct {
 	StoragePool     types.String `tfsdk:"storage_pool"`
 	ImageName       types.String `tfsdk:"image_name"`
 	ImageVersion    types.String `tfsdk:"image_version"`
+	Memory          types.Int64  `tfsdk:"memory"`
+	CPU             types.String `tfsdk:"cpu"`
 	Autostart       types.Bool   `tfsdk:"autostart"`
 	DesiredState    types.String `tfsdk:"desired_state"`
 	StateTimeout    types.Int64  `tfsdk:"state_timeout"`
@@ -139,6 +141,17 @@ func (r *VirtInstanceResource) Schema(ctx context.Context, req resource.SchemaRe
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
+			},
+			"memory": schema.Int64Attribute{
+				Description: "Memory allocation in bytes. Minimum 33554432 (32 MiB).",
+				Optional:    true,
+				Validators: []validator.Int64{
+					int64validator.AtLeast(33554432),
+				},
+			},
+			"cpu": schema.StringAttribute{
+				Description: "CPU allocation (e.g., '2' for 2 cores).",
+				Optional:    true,
 			},
 			"autostart": schema.BoolAttribute{
 				Description: "Whether to start the container automatically on boot. Defaults to false.",
@@ -677,6 +690,14 @@ func (r *VirtInstanceResource) buildCreateOpts(ctx context.Context, data *VirtIn
 		StoragePool:  data.StoragePool.ValueString(),
 	}
 
+	if !data.Memory.IsNull() && !data.Memory.IsUnknown() {
+		opts.Memory = data.Memory.ValueInt64()
+	}
+
+	if !data.CPU.IsNull() && !data.CPU.IsUnknown() {
+		opts.CPU = data.CPU.ValueString()
+	}
+
 	if !data.Autostart.IsNull() && !data.Autostart.IsUnknown() {
 		opts.Autostart = data.Autostart.ValueBool()
 	}
@@ -795,6 +816,18 @@ func (r *VirtInstanceResource) mapVirtInstanceToModel(container *truenas.VirtIns
 	// These fields have RequiresReplace so they don't change during resource lifecycle
 	data.State = types.StringValue(container.Status)
 	data.Autostart = types.BoolValue(container.Autostart)
+
+	if container.Memory > 0 {
+		data.Memory = types.Int64Value(container.Memory)
+	} else {
+		data.Memory = types.Int64Null()
+	}
+
+	if container.CPU != "" {
+		data.CPU = types.StringValue(container.CPU)
+	} else {
+		data.CPU = types.StringNull()
+	}
 
 	// Use container ID as UUID (virt.instance uses name as ID)
 	data.UUID = types.StringValue(container.ID)

--- a/internal/resources/virt_instance_test.go
+++ b/internal/resources/virt_instance_test.go
@@ -145,6 +145,8 @@ type virtInstanceModelParams struct {
 	StoragePool     interface{}
 	ImageName       interface{}
 	ImageVersion    interface{}
+	Memory          interface{}
+	CPU             interface{}
 	Autostart       interface{}
 	DesiredState    interface{}
 	StateTimeout    interface{}
@@ -308,6 +310,8 @@ func createVirtInstanceModelValue(p virtInstanceModelParams) tftypes.Value {
 		"storage_pool":     tftypes.NewValue(tftypes.String, p.StoragePool),
 		"image_name":       tftypes.NewValue(tftypes.String, p.ImageName),
 		"image_version":    tftypes.NewValue(tftypes.String, p.ImageVersion),
+		"memory":           tftypes.NewValue(tftypes.Number, p.Memory),
+		"cpu":              tftypes.NewValue(tftypes.String, p.CPU),
 		"autostart":        tftypes.NewValue(tftypes.Bool, p.Autostart),
 		"desired_state":    tftypes.NewValue(tftypes.String, p.DesiredState),
 		"state_timeout":    tftypes.NewValue(tftypes.Number, p.StateTimeout),
@@ -327,6 +331,8 @@ func createVirtInstanceModelValue(p virtInstanceModelParams) tftypes.Value {
 			"storage_pool":     tftypes.String,
 			"image_name":       tftypes.String,
 			"image_version":    tftypes.String,
+			"memory":           tftypes.Number,
+			"cpu":              tftypes.String,
 			"autostart":        tftypes.Bool,
 			"desired_state":    tftypes.String,
 			"state_timeout":    tftypes.Number,


### PR DESCRIPTION
## Summary

The `truenas_virt_instance` resource currently cannot create containers because it never sets the `memory` field in `buildCreateOpts()`. The underlying `truenas-go` library sends `memory: 0` to the TrueNAS API, which rejects it (minimum 32 MiB).

This PR exposes `memory` (bytes, minimum 33554432) and `cpu` (string, e.g. `"2"`) as optional attributes, wired through to the existing `CreateVirtInstanceOpts` in `truenas-go`.

## Changes

- Add optional `memory` (Int64) and `cpu` (String) attributes to the resource schema
- Wire both fields in `buildCreateOpts()` to the truenas-go library (which already supports them)
- Map both fields from API response in `mapVirtInstanceToModel()`
- Update unit tests (tftypes objects) for new schema fields
- Update documentation

## Testing

All 62 existing unit tests pass with the new fields added. No new test failures introduced.

```
CGO_ENABLED=0 go test ./internal/resources/ -run TestVirtInstanceResource -v
=== PASS (62 tests)
```

## Example Usage

```terraform
resource "truenas_virt_instance" "example" {
  name          = "my-container"
  image_name    = "ubuntu"
  image_version = "24.04"
  storage_pool  = "tank"
  memory        = 4294967296  # 4 GB in bytes
  cpu           = "2"
  autostart     = true
}
```